### PR TITLE
Fix bool-compare and logical-not-parenthesis errors

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -136,8 +136,8 @@ bool write_to_descriptor( DESCRIPTOR_DATA * d, const char *txt, int length );
  * Other local functions (OS-independent).
  */
 bool check_parse_name( const char *name, bool newchar );
-bool check_reconnect( DESCRIPTOR_DATA * d, const char *name, bool fConn );
-bool check_playing( DESCRIPTOR_DATA * d, const char *name, bool kick );
+int check_reconnect( DESCRIPTOR_DATA * d, const char *name, bool fConn );
+int check_playing( DESCRIPTOR_DATA * d, const char *name, bool kick );
 int main( int argc, char **argv );
 void nanny( DESCRIPTOR_DATA * d, char *argument );
 bool flush_buffer( DESCRIPTOR_DATA * d, bool fPrompt );
@@ -182,19 +182,19 @@ void cleanup_memory( void )
    free_morphs(  );
 
    /*
-    * Commands 
+    * Commands
     */
    fprintf( stdout, "%s", "Commands.\n" );
    free_commands(  );
 
    /*
-    * Deities 
+    * Deities
     */
    fprintf( stdout, "%s", "Deities.\n" );
    free_deities(  );
 
    /*
-    * Clans 
+    * Clans
     */
    fprintf( stdout, "%s", "Clans.\n" );
    free_clans(  );
@@ -206,37 +206,37 @@ void cleanup_memory( void )
    free_councils(  );
 
    /*
-    * socials 
+    * socials
     */
    fprintf( stdout, "%s", "Socials.\n" );
    free_socials(  );
 
    /*
-    * Watches 
+    * Watches
     */
    fprintf( stdout, "%s", "Watches.\n" );
    free_watchlist(  );
 
    /*
-    * Helps 
+    * Helps
     */
    fprintf( stdout, "%s", "Helps.\n" );
    free_helps(  );
 
    /*
-    * Languages 
+    * Languages
     */
    fprintf( stdout, "%s", "Languages.\n" );
    free_tongues(  );
 
    /*
-    * Boards 
+    * Boards
     */
    fprintf( stdout, "%s", "Boards.\n" );
    free_boards(  );
 
    /*
-    * Whack supermob 
+    * Whack supermob
     */
    fprintf( stdout, "%s", "Whacking supermob.\n" );
    if( supermob )
@@ -247,7 +247,7 @@ void cleanup_memory( void )
    }
 
    /*
-    * Free Objects 
+    * Free Objects
     */
    clean_obj_queue(  );
    fprintf( stdout, "%s", "Objects.\n" );
@@ -256,7 +256,7 @@ void cleanup_memory( void )
    clean_obj_queue(  );
 
    /*
-    * Free Characters 
+    * Free Characters
     */
    clean_char_queue(  );
    fprintf( stdout, "%s", "Characters.\n" );
@@ -265,7 +265,7 @@ void cleanup_memory( void )
    clean_char_queue(  );
 
    /*
-    * Descriptors 
+    * Descriptors
     */
    fprintf( stdout, "%s", "Descriptors.\n" );
    for( desc = first_descriptor; desc; desc = desc_next )
@@ -276,13 +276,13 @@ void cleanup_memory( void )
    }
 
    /*
-    * Liquids 
+    * Liquids
     */
    fprintf( stdout, "%s", "Liquid Table.\n" );
    free_liquiddata(  );
 
    /*
-    * Races 
+    * Races
     */
    fprintf( stdout, "%s", "Races.\n" );
    for( hash = 0; hash < MAX_RACE; hash++ )
@@ -293,7 +293,7 @@ void cleanup_memory( void )
    }
 
    /*
-    * Classes 
+    * Classes
     */
    fprintf( stdout, "%s", "Classes.\n" );
    for( hash = 0; hash < MAX_CLASS; hash++ )
@@ -303,13 +303,13 @@ void cleanup_memory( void )
    }
 
    /*
-    * Teleport lists 
+    * Teleport lists
     */
    fprintf( stdout, "%s", "Teleport Data.\n" );
    free_teleports(  );
 
    /*
-    * Areas - this includes killing off the hash tables and such 
+    * Areas - this includes killing off the hash tables and such
     */
    fprintf( stdout, "%s", "Area Data Tables.\n" );
    close_all_areas(  );
@@ -321,7 +321,7 @@ void cleanup_memory( void )
    free_all_planes(  );
 
    /*
-    * Get rid of auction pointer  MUST BE AFTER OBJECTS DESTROYED 
+    * Get rid of auction pointer  MUST BE AFTER OBJECTS DESTROYED
     */
    fprintf( stdout, "%s", "Auction.\n" );
    DISPOSE( auction );
@@ -331,7 +331,7 @@ void cleanup_memory( void )
    free_mssp_info();
 
    /*
-    * System Data 
+    * System Data
     */
    fprintf( stdout, "%s", "System data.\n" );
    if( sysdata.time_of_max )
@@ -344,7 +344,7 @@ void cleanup_memory( void )
       STRFREE( sysdata.guild_advisor );
 
    /*
-    * Title table 
+    * Title table
     */
    fprintf( stdout, "%s", "Title table.\n" );
    for( hash = 0; hash < MAX_CLASS; hash++ )
@@ -357,13 +357,13 @@ void cleanup_memory( void )
    }
 
    /*
-    * Skills 
+    * Skills
     */
    fprintf( stdout, "%s", "Skills and Herbs.\n" );
    free_skills(  );
 
    /*
-    * Prog Act lists 
+    * Prog Act lists
     */
    fprintf( stdout, "%s", "Mudprog act lists.\n" );
    free_prog_actlists(  );
@@ -372,7 +372,7 @@ void cleanup_memory( void )
    free_specfuns(  );
 
    /*
-    * Some freaking globals 
+    * Some freaking globals
     */
    fprintf( stdout, "%s", "Globals.\n" );
    DISPOSE( ranged_target_name );
@@ -423,7 +423,7 @@ int main( int argc, char **argv )
    new_boot_time = update_time( localtime( &current_time ) );
    /*
     * Copies *new_boot_time to new_boot_struct, and then points
-    * new_boot_time to new_boot_struct again. -- Alty 
+    * new_boot_time to new_boot_struct again. -- Alty
     */
    new_boot_struct = *new_boot_time;
    new_boot_time = &new_boot_struct;
@@ -435,18 +435,18 @@ int main( int argc, char **argv )
    new_boot_time->tm_hour = 6;
 
    /*
-    * Update new_boot_time (due to day increment) 
+    * Update new_boot_time (due to day increment)
     */
    new_boot_time = update_time( new_boot_time );
    new_boot_struct = *new_boot_time;
    new_boot_time = &new_boot_struct;
    /*
-    * Bug fix submitted by Gabe Yoder 
+    * Bug fix submitted by Gabe Yoder
     */
    new_boot_time_t = mktime( new_boot_time );
    reboot_check( mktime( new_boot_time ) );
    /*
-    * Set reboot time string for do_time 
+    * Set reboot time string for do_time
     */
    get_reboot_string(  );
 
@@ -484,7 +484,7 @@ int main( int argc, char **argv )
 #ifdef WIN32
    {
       /*
-       * Initialise Windows sockets library 
+       * Initialise Windows sockets library
        */
 
       unsigned short wVersionRequested = MAKEWORD( 1, 1 );
@@ -492,7 +492,7 @@ int main( int argc, char **argv )
       int err;
 
       /*
-       * Need to include library: wsock32.lib for Windows Sockets 
+       * Need to include library: wsock32.lib for Windows Sockets
        */
       err = WSAStartup( wVersionRequested, &wsadata );
       if( err )
@@ -502,7 +502,7 @@ int main( int argc, char **argv )
       }
 
       /*
-       * standard termination signals 
+       * standard termination signals
        */
       signal( SIGINT, ( void * )bailout );
       signal( SIGTERM, ( void * )bailout );
@@ -517,7 +517,7 @@ int main( int argc, char **argv )
 
 #ifdef IMC
    /*
-    * Initialize and connect to IMC2 
+    * Initialize and connect to IMC2
     */
    imc_startup( FALSE, imcsocket, fCopyOver );
 #endif
@@ -540,7 +540,7 @@ int main( int argc, char **argv )
 
 #ifdef WIN32
    /*
-    * Shut down Windows sockets 
+    * Shut down Windows sockets
     */
 
    WSACleanup(  );   /* clean up */
@@ -763,13 +763,13 @@ void game_loop( void )
 #endif
 
    /*
-    * signal( SIGSEGV, SegVio ); 
+    * signal( SIGSEGV, SegVio );
     */
    gettimeofday( &last_time, NULL );
    current_time = ( time_t ) last_time.tv_sec;
 
    /*
-    * Main loop 
+    * Main loop
     */
    while( !mud_down )
    {
@@ -829,7 +829,7 @@ void game_loop( void )
             }
 
             /*
-             * check for input from the dns 
+             * check for input from the dns
              */
             if( ( d->connected == CON_PLAYING || d->character != NULL ) && d->ifd != -1 && FD_ISSET( d->ifd, &in_set ) )
                process_dns( d );
@@ -960,7 +960,7 @@ void game_loop( void )
       current_time = ( time_t ) last_time.tv_sec;
    }
    /*
-    * Save morphs so can sort later. --Shaddai 
+    * Save morphs so can sort later. --Shaddai
     */
    if( sysdata.morph_opt )
       save_morphs(  );
@@ -1081,7 +1081,7 @@ void new_descriptor( int new_desc )
    LINK( dnew, first_descriptor, last_descriptor, next, prev );
 
    /*
-    * MCCP Compression 
+    * MCCP Compression
     */
    write_to_buffer( dnew, (const char *)will_compress2_str, 0 );
 
@@ -1144,26 +1144,26 @@ void close_socket( DESCRIPTOR_DATA * dclose, bool force )
       close( dclose->ifd );
 
    /*
-    * flush outbuf 
+    * flush outbuf
     */
    if( !force && dclose->outtop > 0 )
       flush_buffer( dclose, FALSE );
 
    /*
-    * say bye to whoever's snooping this descriptor 
+    * say bye to whoever's snooping this descriptor
     */
    if( dclose->snoop_by )
       write_to_buffer( dclose->snoop_by, "Your victim has left the game.\r\n", 0 );
 
    /*
-    * stop snooping everyone else 
+    * stop snooping everyone else
     */
    for( d = first_descriptor; d; d = d->next )
       if( d->snoop_by == dclose )
          d->snoop_by = NULL;
 
    /*
-    * Check for switched people who go link-dead. -- Altrag 
+    * Check for switched people who go link-dead. -- Altrag
     */
    if( dclose->original )
    {
@@ -1181,7 +1181,7 @@ void close_socket( DESCRIPTOR_DATA * dclose, bool force )
    ch = dclose->character;
 
    /*
-    * sanity check :( 
+    * sanity check :(
     */
    if( !dclose->prev && dclose != first_descriptor )
    {
@@ -1254,7 +1254,7 @@ void close_socket( DESCRIPTOR_DATA * dclose, bool force )
       else
       {
          /*
-          * clear descriptor pointer to get rid of bug message in log 
+          * clear descriptor pointer to get rid of bug message in log
           */
          dclose->character->desc = NULL;
          free_char( dclose->character );
@@ -1264,7 +1264,7 @@ void close_socket( DESCRIPTOR_DATA * dclose, bool force )
    if( !DoNotUnlink )
    {
       /*
-       * make sure loop doesn't get messed up 
+       * make sure loop doesn't get messed up
        */
       if( d_next == dclose )
          d_next = d_next->next;
@@ -1287,13 +1287,13 @@ bool read_from_descriptor( DESCRIPTOR_DATA * d )
    int iErr;
 
    /*
-    * Hold horses if pending command already. 
+    * Hold horses if pending command already.
     */
    if( d->incomm[0] != '\0' )
       return TRUE;
 
    /*
-    * Check for overflow. 
+    * Check for overflow.
     */
    iStart = strlen( d->inbuf );
    if( iStart >= sizeof( d->inbuf ) - 10 )
@@ -1369,7 +1369,7 @@ void read_from_buffer( DESCRIPTOR_DATA * d )
          write_to_descriptor( d, "Line too long.\r\n", 0 );
 
          /*
-          * skip the rest of the line 
+          * skip the rest of the line
           */
          /*
           * for ( ; d->inbuf[i] != '\0' || i>= MAX_INBUF_SIZE ; i++ )
@@ -1529,12 +1529,12 @@ bool flush_buffer( DESCRIPTOR_DATA * d, bool fPrompt )
    if( d->snoop_by )
    {
       /*
-       * without check, 'force mortal quit' while snooped caused crash, -h 
+       * without check, 'force mortal quit' while snooped caused crash, -h
        */
       if( d->character && d->character->name )
       {
          /*
-          * Show original snooped names. -- Altrag 
+          * Show original snooped names. -- Altrag
           */
          if( d->original && d->original->name )
             snprintf( buf, MAX_INPUT_LENGTH, "%s (%s)", d->character->name, d->original->name );
@@ -1613,11 +1613,11 @@ void write_to_buffer( DESCRIPTOR_DATA * d, const char *txt, size_t length )
       if( d->outsize > 32000 )
       {
          /*
-          * empty buffer 
+          * empty buffer
           */
          d->outtop = 0;
          /*
-          * Bugfix by Samson - moved bug() call up 
+          * Bugfix by Samson - moved bug() call up
           */
          bug( "Buffer overflow. Closing (%s).", d->character ? d->character->name : "???" );
          close_socket( d, TRUE );
@@ -1811,7 +1811,7 @@ void show_title( DESCRIPTOR_DATA * d )
 void nanny_get_name( DESCRIPTOR_DATA * d, char *argument )
 {
    CHAR_DATA *ch;
-   bool fOld, chk;
+   bool fOld;
    char buf[MAX_STRING_LENGTH];
 
    ch = d->character;
@@ -1946,11 +1946,10 @@ void nanny_get_name( DESCRIPTOR_DATA * d, char *argument )
       return;
    }
 
-   chk = check_reconnect( d, argument, FALSE );
-   if( chk == BERR )
+   if( check_reconnect( d, argument, FALSE ) == BERR )
       return;
 
-   if( chk )
+   if( check_reconnect( d, argument, FALSE ) )
    {
       fOld = TRUE;
    }
@@ -2018,7 +2017,7 @@ void nanny_get_old_password( DESCRIPTOR_DATA * d, char *argument )
 {
    CHAR_DATA *ch;
    char buf[MAX_STRING_LENGTH];
-   bool fOld, chk;
+   bool fOld;
 
    ch = d->character;
    write_to_buffer( d, "\r\n", 2 );
@@ -2039,15 +2038,14 @@ void nanny_get_old_password( DESCRIPTOR_DATA * d, char *argument )
    if( check_playing( d, ch->pcdata->filename, TRUE ) )
       return;
 
-   chk = check_reconnect( d, ch->pcdata->filename, TRUE );
-   if( chk == BERR )
+   if( check_reconnect( d, ch->pcdata->filename, TRUE ) == BERR )
    {
       if( d->character && d->character->desc )
          d->character->desc = NULL;
       close_socket( d, FALSE );
       return;
    }
-   if( chk == TRUE )
+   if( check_reconnect( d, ch->pcdata->filename, TRUE ) )
       return;
 
    mudstrlcpy( buf, ch->pcdata->filename, MAX_STRING_LENGTH );
@@ -2498,7 +2496,7 @@ void nanny_read_motd( DESCRIPTOR_DATA * d, const char *argument )
          ch->pcdata->learned[iLang] = 100;
 
       /*
-       * Give them their racial languages 
+       * Give them their racial languages
        */
       if( race_table[ch->race] )
       {
@@ -2783,7 +2781,7 @@ bool check_parse_name( const char *name, bool newchar )
 /*
  * Look for link-dead player to reconnect.
  */
-bool check_reconnect( DESCRIPTOR_DATA * d, const char *name, bool fConn )
+int check_reconnect( DESCRIPTOR_DATA * d, const char *name, bool fConn )
 {
    CHAR_DATA *ch;
 
@@ -2798,7 +2796,7 @@ bool check_reconnect( DESCRIPTOR_DATA * d, const char *name, bool fConn )
             if( d->character )
             {
                /*
-                * clear descriptor pointer to get rid of bug message in log 
+                * clear descriptor pointer to get rid of bug message in log
                 */
                d->character->desc = NULL;
                free_char( d->character );
@@ -2814,7 +2812,7 @@ bool check_reconnect( DESCRIPTOR_DATA * d, const char *name, bool fConn )
          else
          {
             /*
-             * clear descriptor pointer to get rid of bug message in log 
+             * clear descriptor pointer to get rid of bug message in log
              */
             d->character->desc = NULL;
             free_char( d->character );
@@ -2841,7 +2839,7 @@ bool check_reconnect( DESCRIPTOR_DATA * d, const char *name, bool fConn )
 /*
  * Check if already playing.
  */
-bool check_playing( DESCRIPTOR_DATA * d, const char *name, bool kick )
+int check_playing( DESCRIPTOR_DATA * d, const char *name, bool kick )
 {
    CHAR_DATA *ch;
    DESCRIPTOR_DATA *dold;
@@ -2867,7 +2865,7 @@ bool check_playing( DESCRIPTOR_DATA * d, const char *name, bool kick )
          write_to_buffer( dold, "Kicking off old connection... bye!\r\n", 0 );
          close_socket( dold, FALSE );
          /*
-          * clear descriptor pointer to get rid of bug message in log 
+          * clear descriptor pointer to get rid of bug message in log
           */
          d->character->desc = NULL;
          free_char( d->character );
@@ -3091,7 +3089,7 @@ char *act_string( const char *format, CHAR_DATA * to, CHAR_DATA * ch, const void
                if( !to || can_see_obj( to, obj1 ) )
                {
                   /*
-                   * Prevents act programs from triggering off note shorts 
+                   * Prevents act programs from triggering off note shorts
                    */
                   if( ( !to || IS_NPC( to ) ) && ( obj1->item_type == ITEM_PAPER ) )
                      i = obj1->pIndexData->short_descr;
@@ -3106,7 +3104,7 @@ char *act_string( const char *format, CHAR_DATA * to, CHAR_DATA * ch, const void
                if( !to || can_see_obj( to, obj2 ) )
                {
                   /*
-                   * Prevents act programs from triggering off note shorts 
+                   * Prevents act programs from triggering off note shorts
                    */
                   if( ( !to || IS_NPC( to ) ) && ( obj2->item_type == ITEM_PAPER ) )
                      i = obj2->pIndexData->short_descr;
@@ -3132,7 +3130,7 @@ char *act_string( const char *format, CHAR_DATA * to, CHAR_DATA * ch, const void
                   i = should_upper ? "It" : "it";
                }
                else
-                  i = should_upper ? 
+                  i = should_upper ?
                    !can_see( to, ch ) ? "It" : capitalize( his_her[URANGE( 0, ch->sex, 2 )] ) :
                    !can_see( to, ch ) ? "it" : his_her[URANGE( 0, ch->sex, 2 )];
                break;
@@ -3144,7 +3142,7 @@ char *act_string( const char *format, CHAR_DATA * to, CHAR_DATA * ch, const void
                   i = should_upper ? "It" : "it";
                }
                else
-                  i = should_upper ? 
+                  i = should_upper ?
                    !can_see( to, vch ) ? "It" : capitalize( his_her[URANGE( 0, vch->sex, 2 )] ) :
                    !can_see( to, vch ) ? "it" : his_her[URANGE( 0, vch->sex, 2 )];
                break;
@@ -3346,7 +3344,7 @@ void act( short AType, const char *format, CHAR_DATA * ch, const void *arg1, con
 
    /*
     * Anyone feel like telling me the point of looping through the whole
-    * room when we're only sending to one char anyways..? -- Alty 
+    * room when we're only sending to one char anyways..? -- Alty
     */
    for( ; to; to = ( type == TO_CHAR || type == TO_VICT ) ? NULL : to->next_in_room )
    {
@@ -3380,7 +3378,7 @@ void act( short AType, const char *format, CHAR_DATA * ch, const void *arg1, con
       if( MOBtrigger )
       {
          /*
-          * Note: use original string, not string with ANSI. -- Alty 
+          * Note: use original string, not string with ANSI. -- Alty
           */
          mprog_act_trigger( txt, to, ch, obj1, vch, obj2 );
       }
@@ -3573,7 +3571,7 @@ void display_prompt( DESCRIPTOR_DATA * d )
    }
 
    /*
-    * Clear out old color stuff 
+    * Clear out old color stuff
     */
    for( ; *prompt; prompt++ )
    {

--- a/src/skills.c
+++ b/src/skills.c
@@ -223,7 +223,7 @@ bool is_legal_kill( CHAR_DATA * ch, CHAR_DATA * vch )
    return TRUE;
 }
 
-/* 
+/*
  * Racial Skills Handling -- Kayle 7-8-07
  */
 bool check_ability( CHAR_DATA * ch, char *command, char *argument )
@@ -353,7 +353,7 @@ bool check_ability( CHAR_DATA * ch, char *command, char *argument )
                   }
 
                   /*
-                   * Too many illegal pk attempts with cuffs, swats etc lately. - Luc 
+                   * Too many illegal pk attempts with cuffs, swats etc lately. - Luc
                    */
                   if( xIS_SET( ch->act, PLR_NICE ) )
                   {
@@ -533,7 +533,7 @@ bool check_skill( CHAR_DATA * ch, char *command, char *argument )
    }
 
    /*
-    * check if mana is required 
+    * check if mana is required
     */
    if( skill_table[sn]->min_mana )
    {
@@ -685,11 +685,11 @@ bool check_skill( CHAR_DATA * ch, char *command, char *argument )
       }
 
       /*
-       * waitstate 
+       * waitstate
        */
       WAIT_STATE( ch, skill_table[sn]->beats );
       /*
-       * check for failure 
+       * check for failure
        */
       if( ( number_percent(  ) + skill_table[sn]->difficulty * 5 ) > ( IS_NPC( ch ) ? 75 : LEARNED( ch, sn ) ) )
       {
@@ -1831,7 +1831,7 @@ void do_sset( CHAR_DATA* ch, const char* argument)
       for( sn = 0; sn < num_skills; ++sn )
       {
          /*
-          * Fix by Narn to prevent ssetting skills the player shouldn't have. 
+          * Fix by Narn to prevent ssetting skills the player shouldn't have.
           */
          if( victim->level >= skill_table[sn]->skill_level[victim->Class]
              || victim->level >= skill_table[sn]->race_level[victim->race] )
@@ -2382,7 +2382,7 @@ void do_dig( CHAR_DATA* ch, const char* argument)
    ch->substate = SUB_NONE;
 
    /*
-    * not having a shovel makes it harder to succeed 
+    * not having a shovel makes it harder to succeed
     */
    shovel = FALSE;
    for( obj = ch->first_carrying; obj; obj = obj->next_content )
@@ -2393,7 +2393,7 @@ void do_dig( CHAR_DATA* ch, const char* argument)
       }
 
    /*
-    * dig out an EX_DIG exit... 
+    * dig out an EX_DIG exit...
     */
    if( arg[0] != '\0' )
    {
@@ -2401,7 +2401,7 @@ void do_dig( CHAR_DATA* ch, const char* argument)
           && IS_SET( pexit->exit_info, EX_DIG ) && IS_SET( pexit->exit_info, EX_CLOSED ) )
       {
          /*
-          * 4 times harder to dig open a passage without a shovel 
+          * 4 times harder to dig open a passage without a shovel
           */
          if( can_use_skill( ch, ( number_percent(  ) * ( shovel ? 1 : 4 ) ), gsn_dig ) )
          {
@@ -2433,7 +2433,7 @@ void do_dig( CHAR_DATA* ch, const char* argument)
    for( obj = startobj; obj; obj = obj->next_content )
    {
       /*
-       * twice as hard to find something without a shovel 
+       * twice as hard to find something without a shovel
        */
       if( IS_OBJ_STAT( obj, ITEM_BURIED ) && ( can_use_skill( ch, ( number_percent(  ) * ( shovel ? 1 : 2 ) ), gsn_dig ) ) )
 /*
@@ -2636,7 +2636,7 @@ void do_steal( CHAR_DATA* ch, const char* argument)
       return;
    }
 
-/* Disabled stealing among players because of complaints naked avatars were 
+/* Disabled stealing among players because of complaints naked avatars were
    running around stealing eq from equipped pkillers. -- Narn
 */
 /*    if ( check_illegal_psteal( ch, victim ) )
@@ -2664,9 +2664,9 @@ void do_steal( CHAR_DATA* ch, const char* argument)
       - ( get_curr_lck( ch ) - 15 ) + ( get_curr_lck( victim ) - 13 );
 
    /*
-    * Changed the level check, made it 10 levels instead of five and made the 
-    * victim not attack in the case of a too high level difference.  This is 
-    * to allow mobprogs where the mob steals eq without having to put level 
+    * Changed the level check, made it 10 levels instead of five and made the
+    * victim not attack in the case of a too high level difference.  This is
+    * to allow mobprogs where the mob steals eq without having to put level
     * checks into the progs.  Also gave the mobs a 10% chance of failure.
     */
    if( ch->level + 10 < victim->level )
@@ -2698,7 +2698,7 @@ void do_steal( CHAR_DATA* ch, const char* argument)
          else
          {
             /*
-             * log_string( buf ); 
+             * log_string( buf );
              */
             if( IS_NPC( ch ) )
             {
@@ -2915,7 +2915,7 @@ void do_backstab( CHAR_DATA* ch, const char* argument)
    }
 
    /*
-    * Added stabbing weapon. -Narn 
+    * Added stabbing weapon. -Narn
     */
    if( ( obj = get_eq_char( ch, WEAR_WIELD ) ) == NULL || ( obj->value[3] != 11 && obj->value[3] != 2 ) )
    {
@@ -2930,7 +2930,7 @@ void do_backstab( CHAR_DATA* ch, const char* argument)
    }
 
    /*
-    * Can backstab a char even if it's hurt as long as it's sleeping. -Narn 
+    * Can backstab a char even if it's hurt as long as it's sleeping. -Narn
     */
    if( victim->hit < victim->max_hit && IS_AWAKE( victim ) )
    {
@@ -3519,7 +3519,7 @@ void do_bash( CHAR_DATA* ch, const char* argument)
    {
       learn_from_success( ch, gsn_bash );
       /*
-       * do not change anything here!  -Thoric 
+       * do not change anything here!  -Thoric
        */
       WAIT_STATE( victim, 2 * PULSE_VIOLENCE );
       victim->position = POS_SITTING;
@@ -3576,7 +3576,7 @@ void do_stun( CHAR_DATA* ch, const char* argument)
    schance = ( ( ( get_curr_dex( victim ) + get_curr_str( victim ) )
                  - ( get_curr_dex( ch ) + get_curr_str( ch ) ) ) * 10 ) + 10;
    /*
-    * harder for player to stun another player 
+    * harder for player to stun another player
     */
    if( !IS_NPC( ch ) && !IS_NPC( victim ) )
       schance += sysdata.stun_plr_vs_plr;
@@ -3586,7 +3586,7 @@ void do_stun( CHAR_DATA* ch, const char* argument)
    {
       learn_from_success( ch, gsn_stun );
       /*
-       * DO *NOT* CHANGE!    -Thoric    
+       * DO *NOT* CHANGE!    -Thoric
        */
       if( !IS_NPC( ch ) )
          ch->move -= ch->max_move / 10;
@@ -4009,7 +4009,7 @@ void do_mistwalk( CHAR_DATA* ch, const char* argument)
    }
 
    /*
-    * Subtract 22 extra bp for mist walk from 0500 to 2100 SB 
+    * Subtract 22 extra bp for mist walk from 0500 to 2100 SB
     */
    if( time_info.hour < 21 && time_info.hour > 5 && !IS_NPC( ch ) )
       gain_condition( ch, COND_BLOODTHIRST, -22 );
@@ -4110,7 +4110,7 @@ void do_pick( CHAR_DATA* ch, const char* argument)
    WAIT_STATE( ch, skill_table[gsn_pick_lock]->beats );
 
    /*
-    * look for guards 
+    * look for guards
     */
    for( gch = ch->in_room->first_person; gch; gch = gch->next_in_room )
    {
@@ -4137,12 +4137,12 @@ void do_pick( CHAR_DATA* ch, const char* argument)
    if( ( pexit = find_door( ch, arg, TRUE ) ) != NULL )
    {
       /*
-       * 'pick door' 
+       * 'pick door'
        */
       /*
-       * ROOM_INDEX_DATA *to_room; 
+       * ROOM_INDEX_DATA *to_room;
        *//*
-       * Unused 
+       * Unused
        */
       EXIT_DATA *pexit_rev;
 
@@ -4175,7 +4175,7 @@ void do_pick( CHAR_DATA* ch, const char* argument)
       learn_from_success( ch, gsn_pick_lock );
       adjust_favor( ch, 9, 1 );
       /*
-       * pick the other side 
+       * pick the other side
        */
       if( ( pexit_rev = pexit->rexit ) != NULL && pexit_rev->to_room == ch->in_room )
       {
@@ -4188,7 +4188,7 @@ void do_pick( CHAR_DATA* ch, const char* argument)
    if( ( obj = get_obj_here( ch, arg ) ) != NULL )
    {
       /*
-       * 'pick object' 
+       * 'pick object'
        */
       if( obj->item_type != ITEM_CONTAINER )
       {
@@ -4325,7 +4325,7 @@ void do_recall( CHAR_DATA* ch, const char* argument)
       location = get_room_index( ROOM_VNUM_DEADLY );
 
    /*
-    * 1998-01-02, h 
+    * 1998-01-02, h
     */
    if( !location && !IS_NPC( ch ) ) /* Obscure crash bug */
       location = get_room_index( race_table[ch->race]->race_recall );
@@ -4589,7 +4589,7 @@ bool check_parry( CHAR_DATA * ch, CHAR_DATA * victim )
    if( IS_NPC( victim ) )
    {
       /*
-       * Tuan was here.  :) 
+       * Tuan was here.  :)
        */
       chances = UMIN( 60, 2 * victim->level );
    }
@@ -4602,7 +4602,7 @@ bool check_parry( CHAR_DATA * ch, CHAR_DATA * victim )
 
    /*
     * Put in the call to chance() to allow penalties for misaligned
-    * clannies.  
+    * clannies.
     */
    if( chances != 0 && victim->morph )
       chances += victim->morph->parry;
@@ -4646,7 +4646,7 @@ bool check_dodge( CHAR_DATA * ch, CHAR_DATA * victim )
       chances += victim->morph->dodge;
 
    /*
-    * Consider luck as a factor 
+    * Consider luck as a factor
     */
    if( !chance( victim, chances + victim->level - ch->level ) )
    {
@@ -4671,7 +4671,7 @@ bool check_tumble( CHAR_DATA * ch, CHAR_DATA * victim )
 
    if( victim->Class != CLASS_THIEF || !IS_AWAKE( victim ) )
       return FALSE;
-   if( !IS_NPC( victim ) && !victim->pcdata->learned[gsn_tumble] > 0 )
+   if( !IS_NPC( victim ) && !( victim->pcdata->learned[gsn_tumble] > 0 ) )
       return FALSE;
    if( IS_PKILL( victim ) )
       mod_tumble_by = sysdata.tumble_pk;
@@ -4743,7 +4743,7 @@ void do_poison_weapon( CHAR_DATA* ch, const char* argument)
       return;
    }
    /*
-    * Now we have a valid weapon...check to see if we have the powder. 
+    * Now we have a valid weapon...check to see if we have the powder.
     */
    for( pobj = ch->first_carrying; pobj; pobj = pobj->next_content )
    {
@@ -4756,7 +4756,7 @@ void do_poison_weapon( CHAR_DATA* ch, const char* argument)
       return;
    }
    /*
-    * Okay, we have the powder...do we have water? 
+    * Okay, we have the powder...do we have water?
     */
    for( wobj = ch->first_carrying; wobj; wobj = wobj->next_content )
    {
@@ -4769,7 +4769,7 @@ void do_poison_weapon( CHAR_DATA* ch, const char* argument)
       return;
    }
    /*
-    * Great, we have the ingredients...but is the thief smart enough? 
+    * Great, we have the ingredients...but is the thief smart enough?
     */
    if( !IS_NPC( ch ) && get_curr_wis( ch ) < 16 )
    {
@@ -4777,7 +4777,7 @@ void do_poison_weapon( CHAR_DATA* ch, const char* argument)
       return;
    }
    /*
-    * And does the thief have steady enough hands? 
+    * And does the thief have steady enough hands?
     */
    if( !IS_NPC( ch ) && ( ( get_curr_dex( ch ) < 17 ) || ch->pcdata->condition[COND_DRUNK] > 0 ) )
    {
@@ -4789,7 +4789,7 @@ void do_poison_weapon( CHAR_DATA* ch, const char* argument)
    percent = ( number_percent(  ) - get_curr_lck( ch ) - 14 );
 
    /*
-    * Check the skill percentage 
+    * Check the skill percentage
     */
    separate_obj( pobj );
    separate_obj( wobj );
@@ -4807,7 +4807,7 @@ void do_poison_weapon( CHAR_DATA* ch, const char* argument)
    }
    separate_obj( obj );
    /*
-    * Well, I'm tired of waiting.  Are you? 
+    * Well, I'm tired of waiting.  Are you?
     */
    act( AT_RED, "You mix $p in $P, creating a deadly poison!", ch, pobj, wobj, TO_CHAR );
    act( AT_RED, "$n mixes $p in $P, creating a deadly poison!", ch, pobj, wobj, TO_ROOM );
@@ -4816,7 +4816,7 @@ void do_poison_weapon( CHAR_DATA* ch, const char* argument)
    xSET_BIT( obj->extra_flags, ITEM_POISONED );
    obj->cost *= 2;
    /*
-    * Set an object timer.  Don't want proliferation of poisoned weapons 
+    * Set an object timer.  Don't want proliferation of poisoned weapons
     */
    obj->timer = UMIN( obj->level, ch->level );
 
@@ -4827,7 +4827,7 @@ void do_poison_weapon( CHAR_DATA* ch, const char* argument)
       obj->timer *= 2;
 
    /*
-    * WHAT?  All of that, just for that one bit?  How lame. ;) 
+    * WHAT?  All of that, just for that one bit?  How lame. ;)
     */
    act( AT_BLUE, "The remainder of the poison eats through $p.", ch, wobj, NULL, TO_CHAR );
    act( AT_BLUE, "The remainder of the poison eats through $p.", ch, wobj, NULL, TO_ROOM );
@@ -5094,7 +5094,7 @@ bool check_grip( CHAR_DATA * ch, CHAR_DATA * victim )
       schance = ( int )( LEARNED( victim, gsn_grip ) / 2 );
 
    /*
-    * Consider luck as a factor 
+    * Consider luck as a factor
     */
    schance += ( 2 * ( get_curr_lck( victim ) - 13 ) );
 
@@ -5226,12 +5226,12 @@ void do_berserk( CHAR_DATA* ch, const char* argument)
    /*
     * Hmmm.. 10-20 combat rounds at level 50.. good enough for most mobs,
     * and if not they can always go berserk again.. shrug.. maybe even
-    * too high. -- Altrag 
+    * too high. -- Altrag
     */
    af.duration = number_range( ch->level / 5, ch->level * 2 / 5 );
    /*
     * Hmm.. you get stronger when yer really enraged.. mind over matter
-    * type thing.. 
+    * type thing..
     */
    af.location = APPLY_STR;
    af.modifier = 1;
@@ -5280,7 +5280,7 @@ void do_hitall( CHAR_DATA* ch, const char* argument)
       else
          global_retcode = damage( ch, vch, 0, TYPE_UNDEFINED );
       /*
-       * Fireshield, etc. could kill ch too.. :>.. -- Altrag 
+       * Fireshield, etc. could kill ch too.. :>.. -- Altrag
        */
       if( global_retcode == rCHAR_DIED || global_retcode == rBOTH_DIED || char_died( ch ) )
          return;
@@ -5589,7 +5589,7 @@ ch_ret ranged_got_target( CHAR_DATA * ch, CHAR_DATA * victim, OBJ_DATA * weapon,
    if( xIS_SET( ch->in_room->room_flags, ROOM_SAFE ) )
    {
       /*
-       * safe room, bubye projectile 
+       * safe room, bubye projectile
        */
       if( projectile )
       {
@@ -5619,7 +5619,7 @@ ch_ret ranged_got_target( CHAR_DATA * ch, CHAR_DATA * victim, OBJ_DATA * weapon,
          learn_from_failure( ch, gsn_missile_weapons );
 
          /*
-          * 50% chance of projectile getting lost 
+          * 50% chance of projectile getting lost
           */
          if( number_percent(  ) < 50 )
             extract_obj( projectile );
@@ -5650,7 +5650,7 @@ ch_ret ranged_got_target( CHAR_DATA * ch, CHAR_DATA * victim, OBJ_DATA * weapon,
       if( projectile )
       {
          /*
-          * 50% chance of getting lost 
+          * 50% chance of getting lost
           */
          if( number_percent(  ) < 50 )
             extract_obj( projectile );
@@ -5703,7 +5703,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
    victim = NULL;
 
    /*
-    * get an exit or a victim 
+    * get an exit or a victim
     */
    if( ( pexit = find_door( ch, arg, TRUE ) ) == NULL )
    {
@@ -5720,7 +5720,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
             return rNONE;
          }
          /*
-          * Taken out because of waitstate 
+          * Taken out because of waitstate
           * if ( !IS_NPC(ch) && !IS_NPC(victim) )
           * {
           * send_to_char("Pkill like a real pkiller.\r\n", ch );
@@ -5733,7 +5733,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
       dir = pexit->vdir;
 
    /*
-    * check for ranged attacks from private rooms, etc 
+    * check for ranged attacks from private rooms, etc
     */
    if( !victim )
    {
@@ -5765,7 +5765,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
    }
 
    /*
-    * Check for obstruction 
+    * Check for obstruction
     */
    if( pexit && IS_SET( pexit->exit_info, EX_CLOSED ) )
    {
@@ -5793,7 +5793,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
        * }
        */
       /*
-       * don't allow attacks on mobs that are in a no-missile room --Shaddai 
+       * don't allow attacks on mobs that are in a no-missile room --Shaddai
        */
       if( xIS_SET( vch->in_room->room_flags, ROOM_NOMISSILE ) )
       {
@@ -5810,7 +5810,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
        */
 
       /*
-       * can't properly target someone heavily in battle 
+       * can't properly target someone heavily in battle
        */
       if( vch->num_fighting > MAX_FIGHT )
       {
@@ -5870,7 +5870,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
       else
          stxt = skill->name;
       /*
-       * a plain "spell" flying around seems boring 
+       * a plain "spell" flying around seems boring
        */
       if( !str_cmp( stxt, "spell" ) )
          stxt = "magical burst of energy";
@@ -5897,7 +5897,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
    }
 
    /*
-    * victim in same room 
+    * victim in same room
     */
    if( victim )
    {
@@ -5907,12 +5907,12 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
    }
 
    /*
-    * assign scanned victim 
+    * assign scanned victim
     */
    victim = vch;
 
    /*
-    * reverse direction text from move_char 
+    * reverse direction text from move_char
     */
    dtxt = rev_exit( pexit->vdir );
 
@@ -5924,7 +5924,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
       if( IS_SET( pexit->exit_info, EX_CLOSED ) )
       {
          /*
-          * whadoyahknow, the door's closed 
+          * whadoyahknow, the door's closed
           */
          if( projectile )
             snprintf( buf, MAX_STRING_LENGTH, "You see your %s pierce a door in the distance to the %s.",
@@ -5949,7 +5949,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
       }
 
       /*
-       * no victim? pick a random one 
+       * no victim? pick a random one
        */
       if( !victim )
       {
@@ -5970,7 +5970,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
       }
 
       /*
-       * In the same room as our victim? 
+       * In the same room as our victim?
        */
       if( victim && ch->in_room == victim->in_room )
       {
@@ -5980,7 +5980,7 @@ ch_ret ranged_attack( CHAR_DATA * ch, const char *argument, OBJ_DATA * weapon, O
             act( color, "$t flies in from $T.", ch, aoran( stxt ), dtxt, TO_ROOM );
 
          /*
-          * get back before the action starts 
+          * get back before the action starts
           */
          char_from_room( ch );
          char_to_room( ch, was_in_room );
@@ -6085,7 +6085,7 @@ void do_fire( CHAR_DATA* ch, const char* argument)
    }
 
    /*
-    * modify maximum distance based on bow-type and ch's class/str/etc 
+    * modify maximum distance based on bow-type and ch's class/str/etc
     */
    max_dist = URANGE( 1, bow->value[4], 10 );
 
@@ -6116,12 +6116,12 @@ void do_fire( CHAR_DATA* ch, const char* argument)
    }
 
    /*
-    * Add wait state to fire for pkill, etc... 
+    * Add wait state to fire for pkill, etc...
     */
    WAIT_STATE( ch, 6 );
 
    /*
-    * handle the ranged attack 
+    * handle the ranged attack
     */
    ranged_attack( ch, argument, bow, arrow, TYPE_HIT + arrow->value[3], max_dist );
 
@@ -6149,7 +6149,7 @@ bool mob_fire( CHAR_DATA * ch, const char *name )
       return FALSE;
 
    /*
-    * modify maximum distance based on bow-type and ch's class/str/etc 
+    * modify maximum distance based on bow-type and ch's class/str/etc
     */
    max_dist = URANGE( 1, bow->value[4], 10 );
 
@@ -6161,9 +6161,9 @@ bool mob_fire( CHAR_DATA * ch, const char *name )
    return TRUE;
 }
 
-/* -- working on -- 
+/* -- working on --
  * Syntaxes: throw object  (assumed already fighting)
- *	     throw object direction target  (all needed args for distance 
+ *	     throw object direction target  (all needed args for distance
  *	          throwing)
  *	     throw object  (assumed same room throw)
 
@@ -6188,7 +6188,7 @@ void do_throw( CHAR_DATA* ch, const char* argument)
 	throw_obj = throw_obj=>prev_content )
   {
 ---    if ( can_see_obj( ch, throw_obj )
-	&& ( throw_obj->wear_loc == WEAR_HELD || throw_obj->wear_loc == 
+	&& ( throw_obj->wear_loc == WEAR_HELD || throw_obj->wear_loc ==
 	WEAR_WIELDED || throw_obj->wear_loc == WEAR_DUAL_WIELDED )
 	&& nifty_is_name( arg, throw_obj->name ) )
       break;
@@ -6226,7 +6226,7 @@ void do_throw( CHAR_DATA* ch, const char* argument)
       if ( ( ( victim = get_char_room( ch, arg1 ) ) == NULL )
   	&& ( arg2[0] == '\0' ) )
       {
-        act( AT_GREY, "Throw $t at whom?", ch, obj->short_descr, NULL,  
+        act( AT_GREY, "Throw $t at whom?", ch, obj->short_descr, NULL,
 	  TO_CHAR );
         return;
       }
@@ -6324,7 +6324,7 @@ void do_slice( CHAR_DATA* ch, const char* argument)
    return;
 }
 
-/*------------------------------------------------------------ 
+/*------------------------------------------------------------
  *  Fighting Styles - haus
  */ void do_style( CHAR_DATA * ch, const char *argument )
 {
@@ -6357,7 +6357,7 @@ void do_slice( CHAR_DATA* ch, const char* argument)
       if( number_percent(  ) < LEARNED( ch, gsn_style_evasive ) )
       {
          /*
-          * success 
+          * success
           */
          if( ch->fighting )
          {
@@ -6373,7 +6373,7 @@ void do_slice( CHAR_DATA* ch, const char* argument)
       else
       {
          /*
-          * failure 
+          * failure
           */
          send_to_char( "You nearly trip in a lame attempt to adopt an evasive fighting style.\r\n", ch );
          return;
@@ -6390,7 +6390,7 @@ void do_slice( CHAR_DATA* ch, const char* argument)
       if( number_percent(  ) < LEARNED( ch, gsn_style_defensive ) )
       {
          /*
-          * success 
+          * success
           */
          if( ch->fighting )
          {
@@ -6406,7 +6406,7 @@ void do_slice( CHAR_DATA* ch, const char* argument)
       else
       {
          /*
-          * failure 
+          * failure
           */
          send_to_char( "You nearly trip in a lame attempt to adopt a defensive fighting style.\r\n", ch );
          return;
@@ -6423,7 +6423,7 @@ void do_slice( CHAR_DATA* ch, const char* argument)
       if( number_percent(  ) < LEARNED( ch, gsn_style_standard ) )
       {
          /*
-          * success 
+          * success
           */
          if( ch->fighting )
          {
@@ -6439,7 +6439,7 @@ void do_slice( CHAR_DATA* ch, const char* argument)
       else
       {
          /*
-          * failure 
+          * failure
           */
          send_to_char( "You nearly trip in a lame attempt to adopt a standard fighting style.\r\n", ch );
          return;
@@ -6456,7 +6456,7 @@ void do_slice( CHAR_DATA* ch, const char* argument)
       if( number_percent(  ) < LEARNED( ch, gsn_style_aggressive ) )
       {
          /*
-          * success 
+          * success
           */
          if( ch->fighting )
          {
@@ -6472,7 +6472,7 @@ void do_slice( CHAR_DATA* ch, const char* argument)
       else
       {
          /*
-          * failure 
+          * failure
           */
          send_to_char( "You nearly trip in a lame attempt to adopt an aggressive fighting style.\r\n", ch );
          return;
@@ -6489,7 +6489,7 @@ void do_slice( CHAR_DATA* ch, const char* argument)
       if( number_percent(  ) < LEARNED( ch, gsn_style_berserk ) )
       {
          /*
-          * success 
+          * success
           */
          if( ch->fighting )
          {
@@ -6505,7 +6505,7 @@ void do_slice( CHAR_DATA* ch, const char* argument)
       else
       {
          /*
-          * failure 
+          * failure
           */
          send_to_char( "You nearly trip in a lame attempt to adopt a berserk fighting style.\r\n", ch );
          return;


### PR DESCRIPTION
Fixes for these warnings/errors:

**comm.c**
comm.c: In function ‘void nanny_get_name(DESCRIPTOR_DATA_, char_)’:
comm.c:1878:44: error: comparison of constant ‘255’ with boolean expression is always false [-Werror=bool-compare]
    if( check_playing( d, argument, FALSE ) == BERR )
                                            ^
comm.c:1950:12: error: comparison of constant ‘255’ with boolean expression is always false [-Werror=bool-compare]
    if( chk == BERR )
            ^
comm.c: In function ‘void nanny_get_old_password(DESCRIPTOR_DATA_, char_)’:
comm.c:2043:12: error: comparison of constant ‘255’ with boolean expression is always false [-Werror=bool-compare]
    if( chk == BERR )
            ^
comm.c: In function ‘void do_name(CHAR_DATA_, const char_)’:
comm.c:3414:51: error: comparison of constant ‘255’ with boolean expression is always false [-Werror=bool-compare]
    if( check_playing( ch->desc, argument, FALSE ) == BERR )

**skills.c**
skills.c: In function ‘bool check_tumble(CHAR_DATA_, CHAR_DATA_)’:
skills.c:4674:66: error: logical not is only applied to the left hand side of comparison [-Werror=logical-not-parentheses]
    if( !IS_NPC( victim ) && !victim->pcdata->learned[gsn_tumble] > 0 )
